### PR TITLE
Always use versions for external modules

### DIFF
--- a/lib/externals.js
+++ b/lib/externals.js
@@ -64,7 +64,7 @@ module.exports = searchPath =>
                         versions.length === 1 &&
                         semver.satisfies(webtaskModule.version, versions[0])
                       ) {
-                        output.compatible[moduleName] = true;
+                        output.compatible[moduleName] = webtaskModule.version;
                       } else {
                         output.incompatible[moduleName] = {
                           local: versions,


### PR DESCRIPTION
We're keep running into same bug (express-tools vs express-tools@1.1.6), so this PR should fix it by using proper versions for compatible modules instead of using default versions.