### PR TITLE
Proxy PR_NUMBER var for PR builds

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,6 +50,8 @@ module.exports = (pkg, webtaskJson, rootPath, args, ext) => {
     settings[k] = JSON.stringify(settings[k]);
   });
 
+  if (process.env.PR_NUMBER) settings.PR_NUMBER = process.env.PR_NUMBER;
+
   const activePlugins = [];
   const activeLoaders = [];
 


### PR DESCRIPTION
## ✏️ Changes
  
This PR proxies the PR_NUMBER environment variable during the build phase (if available) to the extension's settings which can then be used to conditionally select CDNs/buckets depending on it's presence.

## 🔗 References
  
- https://auth0team.atlassian.net/browse/KEY-321