### PR TITLE
Additional settings (v1.0)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,17 +25,16 @@ module.exports = (pkg, webtaskJson, rootPath, args, externals) => {
   const dependencies = pkg.dependencies;
   const mappings = extension.externals || [];
   const excluded = extension.excluded || ['express-conditional-middleware', 'pino'];
+  const additionalSettings = _.pickBy(process.env, (val, key) => key.startsWith('A0EXT_') || key === 'PR_NUMBER');
   const settings = _.assign(extension.settings, {
     NODE_ENV: 'production',
     CLIENT_VERSION: webtaskJson.version
-  });
+  }, additionalSettings);
 
   // Transform to JSON.
   Object.keys(settings).forEach((k) => {
     settings[k] = JSON.stringify(settings[k]);
   });
-  
-  if (process.env.PR_NUMBER) settings.PR_NUMBER = process.env.PR_NUMBER;
 
   const activePlugins = [];
   const activeLoaders = [];


### PR DESCRIPTION
## ✏️ Changes
Ability to specify additional settings through `process.env`.
Any items from `process.env`, which keys starts with `A0EXT_` will be used as extension settings during build process. This will allow us to add more settings as we need them, without updating `auth0-extensions-cli`.
  
## 🎯 Testing
✅This change has been tested locally