### PR TITLE
banner plugin for 'use strict' at top of bundle

### DIFF
--- a/lib/client-config.js
+++ b/lib/client-config.js
@@ -74,7 +74,7 @@ module.exports = ({ name, version }, rootPath, mode, entry, destination) => {
         {
           test: /\.css$/,
           use: [
-            'css-loader',
+            (mode === developmentMode ? 'style-loader' : 'css-loader'),
             {
               loader: 'postcss-loader',
               options: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -124,6 +124,14 @@ module.exports = (pkg, webtaskJson, rootPath, args, ext) => {
     })
   );
 
+  // add "use strict" to the very beginning of the bundle to avoid some of node4 issues
+  activePlugins.push(
+    new Webpack.BannerPlugin({
+      banner: '"use strict";',
+      raw: true
+    })
+  );
+
   // Return config.
   return {
     entry: path.join(rootPath, args.entryPoint),

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -90,6 +90,12 @@ const defaultWebpackConfig = {
           NODE_ENV: '"production"'
         }
       }
+    },
+    {
+      options: {
+        banner: '"use strict";',
+        raw: true
+      }
     }
   ],
   resolve: {
@@ -112,6 +118,9 @@ describe('config', () => {
 
       expect(result.plugins[0].options.warningsFilter).to.be.a('function');
       delete result.plugins[0].options.warningsFilter;
+
+      expect(result.plugins[2].banner).to.be.a('function');
+      delete result.plugins[2].banner;
 
       expect(result).to.eql(defaultWebpackConfig);
     });


### PR DESCRIPTION
## ✏️ Changes
  We're having issue with `on-install`/`on-uninstall` hooks in the `sso-dashboard` extension on node4. This issue is related to `const` scope in node 4, and can be fixed by `use strict`.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1553747658001800
  
## 🎯 Testing
✅ This change has been tested locally
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time