### PR TITLE
no compress.conditionals for prod

### DIFF
--- a/lib/client-config.js
+++ b/lib/client-config.js
@@ -149,7 +149,7 @@ module.exports = ({ name, version }, rootPath, mode, entry, destination) => {
             compress: {
               sequences: true,
               dead_code: true,
-              conditionals: true,
+              conditionals: false,
               booleans: true,
               unused: true,
               if_return: true,


### PR DESCRIPTION
## ✏️ Changes
  Apparently, `compress.conditionals = true` is breaking DAE UI. Disabled that option for the greater good.

## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅This can be deployed any time