### PR TITLE
added --pkg option to specify package.json (for monorepos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .nyc_output
 coverage
+testing
 npm-debug.log
 yarn-error.log
 *.swp

--- a/bin/a0-ext
+++ b/bin/a0-ext
@@ -25,9 +25,12 @@ prog
     'destinationFolder',
     'Folder where to store the output of the build'
   )
-  .action(args => {
+  .option('--pkg', 'Path of package.json')
+  .action((args, opts) => {
     const rootPath = process.cwd();
-    json(path.join(rootPath, 'package.json')).then(pkg => {
+    const packagePath = path.join(rootPath, opts.pkg || 'package.json');
+
+    json(packagePath).then((pkg) => {
       console.log(
         'Building:',
         chalk.bold(`${pkg.name}@${pkg.version} extension`)
@@ -35,7 +38,7 @@ prog
 
       getExternals(rootPath)
         .then(externals => getConfig(pkg, rootPath, args, externals))
-        .then(config => {
+        .then((config) => {
           Webpack(config).run((err, stats) => {
             if (err) {
               console.log('Error:', chalk.bold(JSON.stringify(err, null, 2)));
@@ -77,12 +80,15 @@ prog
   )
   .argument('entryPoint', 'Entry point for your extension')
   .argument('destinationFolder', 'Entry point for your extension')
-  .action(args => {
+  .option('--pkg', 'Path of package.json')
+  .action((args, opts) => {
     const rootPath = process.cwd();
     const entry = args.entryPoint || 'client/app.jsx';
     const destination = args.destinationFolder || 'dist';
     const mode = 'production';
-    json(path.join(rootPath, 'package.json')).then(pkg => {
+    const packagePath = path.join(rootPath, opts.pkg || 'package.json');
+
+    json(packagePath).then((pkg) => {
       console.log('Building:', chalk.bold(`${pkg.name}@${pkg.version} client`));
 
       Webpack(getClientConfig(pkg, rootPath, mode, entry, destination)).run(
@@ -107,12 +113,12 @@ prog
     'Check extension`s package.json to contain all necessary information'
   )
   .argument('entryPoint', 'Entry point for your extension')
-  .action(args => {
+  .action((args) => {
     const rootPath = process.cwd();
     const entry = args.entryPoint || 'package.json';
     const packagePath = path.join(rootPath, entry);
 
-    json(packagePath).then(pkg => {
+    json(packagePath).then((pkg) => {
       console.log(`Validating ${packagePath}`);
 
       const result = validator.validate(pkg, true);
@@ -127,14 +133,15 @@ prog
     });
   })
   .command('package', 'Package assets for extension deployment')
+  .option('--pkg', 'Path of package.json')
   .option('--client', 'Path of client side assets')
   .option('--bundle', 'Path to extensions bundle')
   .option('--out', 'Directory to copy build package')
   .action((args, opts) => {
     const rootPath = process.cwd();
-    const packagePath = path.join(rootPath, 'package.json');
+    const packagePath = path.join(rootPath, opts.pkg || 'package.json');
 
-    json(packagePath).then(pkg => {
+    json(packagePath).then((pkg) => {
       console.log(`Validating ${packagePath}`);
 
       const result = validator.validate(pkg, true);
@@ -164,14 +171,14 @@ prog
       zip.addLocalFile(packagePath);
       zip.addLocalFile(bundlePath, '', 'extension.js');
       if (clientPath) {
-        zip.addLocalFolder(clientPath, 'client', filename => {
-          return filename.endsWith('.js') || filename.endsWith('.css');
-        });
+        zip.addLocalFolder(clientPath,
+          'client',
+          filename => filename.endsWith('.js') || filename.endsWith('.css'));
       }
 
       const zipName = path.join(outPath, 'package.zip');
 
-      return zip.writeZip(zipName, err => {
+      return zip.writeZip(zipName, (err) => {
         if (err) {
           console.log('Error:', `Unable to package ${zipName}`);
           return process.exit(1);
@@ -208,7 +215,7 @@ prog
           console.log('Extension has been deployed successfully');
           return process.exit(0);
         },
-        err => {
+        (err) => {
           console.log('Deploy process failed');
           console.log((err.response && err.response.error) || err);
           return process.exit(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extensions-cli",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "a0-ext": "./bin/a0-ext"
   },
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "mocha './test/**/*.test.js' --timeout 10000"
   },
   "dependencies": {
     "@babel/core": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extensions-cli",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Command-line tool allowing you to build a Node.js backend as an Auth0 Extension",
   "engines": {
     "node": ">=6.9.1"

--- a/test/bin/build-server.test.js
+++ b/test/bin/build-server.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { expect } = require('chai');
+const { exec } = require('child_process');
+
+const TESTING_DIR = path.join(process.cwd(), 'testing');
+
+const prepareDirectory = (dir) => {
+  try {
+    fs.statSync(dir);
+  } catch (e) {
+    fs.mkdirSync(dir);
+  }
+};
+
+describe('build:server', () => {
+  it('should build extension bundle', (done) => {
+    prepareDirectory(TESTING_DIR);
+
+    exec('node ./bin/a0-ext build:server ./test/mocks/extension.js ./testing --pkg ./test/mocks/good.json', (err) => {
+      expect(err).to.equal(null);
+      const bundleContent = fs.readFileSync(path.join(TESTING_DIR, 'auth0-dummy-extension.extension.1.0.0.js'), 'utf8');
+
+      expect(bundleContent.startsWith('"use strict"')).to.equal(true);
+      expect(bundleContent).to.contain('require("some-module")');
+      expect(bundleContent).to.contain('("test string")');
+
+      done();
+    });
+  });
+});

--- a/test/mocks/extension.js
+++ b/test/mocks/extension.js
@@ -1,0 +1,6 @@
+const some = require('some-module');
+
+module.exports = (context, req, res) => {
+  const test = some('test string');
+  return res.send(test);
+};

--- a/test/mocks/good.json
+++ b/test/mocks/good.json
@@ -25,6 +25,7 @@
     },
     "externals": [
       "auth0",
+      "some-module",
       "webtask-tools"
     ],
     "excluded": [


### PR DESCRIPTION
## ✏️ Changes
  Currently, the CLI is using `./package.json` from root. To use the CLI with monorepos (like `logs-to-provider` or `deploy-extensions`) we need to be able to use specific `package.json`.
